### PR TITLE
基于`filow/gulp_h5packer`0.3.0版本进行优化与bug修复

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,85 +1,93 @@
 # gulp-inline-src
 
-移动H5页面打包工具
+资源内联插件，对html或js中引用的外部资源通过内联方式嵌入
 
-为了减少移动端H5页面的请求数量，往往会在发布前将页面依赖的JS, CSS文件嵌入html中，如果一些资源有全局资源包的支持，也会将其替换为CDN地址。
+## 快速开始
 
-本插件可以根据link, script, img标签中的标记，选择将文件内容嵌入或者替换为CDN地址。
+### html中内联
 
-## 关键版本节点
+  - 样式
 
-0.4.0: 基于`filow/gulp_h5packer`0.3.0版本进行优化与bug修复
-  - 解决关闭压缩后注入空脚本问题
-  - 解决压缩es2015规范代码异常
-  - 解决`htmlTag`配置变更后`staticUrl`替换失败问题
-  - 增加压缩是否采用严格模式配置
-  - 修改`htmlTag`默认值为`inline`
+    ```html
+    <link rel="stylesheet" type="text/css" href="animate.css" data-inline="true">
+    ```
 
-0.3.0: 脱离支付宝H5开发环境独立发展
+    内联CDN资源
 
-0.2.0: 替换HTML解析引擎为cheerio，提升2倍以上的效率
-       增加对配置项的支持
+    ```html
+    <link rel="stylesheet" type="text/css" href="animate.css" data-inline="true" data-inline="static-animate">
+    ```
 
-0.1.7: 可以支持网络文件的嵌入和BASE64
+    参数
 
-0.1.6: 支持img标签内图片的BASE64, 支持js和CSS的压缩
+    ```js
+    {
+      staticUrl: {
+        animate: 'http://apps.bdimg.com/libs/animate.css/3.1.0/animate.min.css'
+      }
+    }
+    ```
 
+  - 脚本
 
-## 用法
+    ```html
+    <script src="zepto.js" data-inline="true"></script>
+    ```
 
-首先，在待处理的html文件中加入标记。标记共有三种：
+    内联CDN资源
 
-### 内容替换标记
+    ```html
+    <script src="zepto.js" data-inline="true" data-inline="static-zepto"></script>
+    ```
 
-```html
-<link rel="stylesheet" type="text/css" href="something.css" data-inline="true">
-<script src="something.js" data-inline="true"></script>
-```
+    参数
 
-这样会读取资源文件，把内容嵌入在标签的位置。script标签会删去src和data-inline属性，并在标签内嵌入内容。link标签会在后面产生一个style节点，并嵌入内容。标签本身会被删除。
+    ```js
+    {
+      staticUrl: {
+        zepto: 'http://apps.bdimg.com/libs/zepto/1.1.4/zepto.min.js'
+      }
+    }
+    ```
 
-### 资源URL替换标记
+  - 图片
 
-```html
-<link rel="stylesheet" type="text/css" href="local/animate.css" data-inline="static-animate">
-<script src="local/zepto.js" data-inline="static-zepto"></script>
-```
+  ```html
+  <img src="fake.png" data-inline="base64">
+  ```
 
-在data-inline中写入"static-全局资源包名称"，即可替换为相应的地址。
+  > 注：目前Base64转码不考虑文件大小因素，请不要在大图片上加这个标记！
 
-该功能由于目前脱离了支付宝环境，暂时没有默认值，请在初始化参数中传入：
-```js
-{
-  staticUrl: {
-    animate: 'http://apps.bdimg.com/libs/animate.css/3.1.0/animate.min.css'
-    ,zepto: 'http://apps.bdimg.com/libs/zepto/1.1.4/zepto.min.js'
-  }
-}
+### 脚本中内联
 
-```
-
-### 图片Base64转化标记
-```html
-<img src="fake.png" data-inline="base64">
-```
-注意： 目前Base64转码不考虑文件大小因素，请不要在大图片上加这个标记！
+  ```js
+  __inline("./plugin/tinymce-plugin-autosave.js")
+  var uploadTpl = __inline('./tpls/upload.html');
+  var EDITOR_CONFIG = __inline('./config/config.json');
+  ```
 
 ## 引用
-设置完HTML后，在gulpfile.js中引用：
-```js
-gulp.task('pack', function (){
-  var inline = require('gulp-inline-src');
-  gulp.src('./build/*/*.html')
-    .pipe(inline())
+
+  ```js
+  let inline = require('gulp-inline-src');
+  gulp.task('inline', function (){
+    var options = {
+      staticUrl: {
+        animate: 'http://apps.bdimg.com/libs/animate.css/3.1.0/animate.min.css'
+        ,zepto: 'http://apps.bdimg.com/libs/zepto/1.1.4/zepto.min.js'
+      }
+    };
+    gulp.src('./index.html')
+    .pipe(inline(options))
     .pipe(gulp.dest('./public'));
-});
-```
+  })
+  ```
 
 ## 参数
 
 | 属性 | 描述 | 是否必须 | 值类型 | 默认值 |
 |---- |:-------------:|:----:|:----:| ----:| 
-| `htmlTag` | 用于识别的属性 | 否 | {String} | "replace" |
+| `htmlTag` | 用于识别的属性 | 否 | {String} | "inline" |
 | `cssmin` | 是否开启css压缩 | 否 | {Boolean} | true |
 | `jsmin` | 是否开启js压缩 | 否 | {Boolean} | true |
 | `strict` | 是否使用严格模式 | 否 | {Boolean} | true |
@@ -91,3 +99,20 @@ gulp.task('pack', function (){
 > 注：
 > - `clean-css`版本为`~3.3.7`
 > - `uglify-js`版本为`~2.4.24`
+
+## 版本
+
+- 0.4.2: 新增`__inline`语法，支持在脚本中内联外部js或html资源
+
+- 0.4.1: 修改代码仓库名称
+
+- 0.4.0: 基于`filow/gulp_h5packer`0.3.0版本进行优化与bug修复
+  - 解决关闭压缩后注入空脚本问题
+  - 解决压缩es2015规范代码异常
+  - 解决`htmlTag`配置变更后`staticUrl`替换失败问题
+  - 增加压缩是否采用严格模式配置
+  - 修改`htmlTag`默认值为`inline`
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gulp-inline
+# gulp-inline-src
 
 移动H5页面打包工具
 
@@ -68,7 +68,7 @@
 设置完HTML后，在gulpfile.js中引用：
 ```js
 gulp.task('pack', function (){
-  var inline = require('gulp-inline');
+  var inline = require('gulp-inline-src');
   gulp.src('./build/*/*.html')
     .pipe(inline())
     .pipe(gulp.dest('./public'));

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@
   - 样式
 
     ```html
-    <link rel="stylesheet" type="text/css" href="animate.css" data-inline="true">
+    <link data-inline="true" href="animate.css" rel="stylesheet" type="text/css">
     ```
 
     内联CDN资源
 
     ```html
-    <link rel="stylesheet" type="text/css" href="animate.css" data-inline="true" data-inline="static-animate">
+    <link data-inline="static-animate" href="animate.css" rel="stylesheet" type="text/css">
     ```
 
     参数
@@ -31,13 +31,13 @@
   - 脚本
 
     ```html
-    <script src="zepto.js" data-inline="true"></script>
+    <script data-inline="true" src="zepto.js"></script>
     ```
 
     内联CDN资源
 
     ```html
-    <script src="zepto.js" data-inline="true" data-inline="static-zepto"></script>
+    <script data-inline="static-zepto" src="zepto.js"></script>
     ```
 
     参数

--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@
 
 ## 版本
 
+- 0.4.4: 修复bug
+  - 修复`ignoreCompressFolders`属性在`windows`平台失效问题
+  - `jsmin`属性为true且文件大小>500kb，消除`babel-core`的警告提示
+
+- 0.4.3: 修改`README.md`的描述
+
 - 0.4.2: 新增`__inline`语法，支持在脚本中内联外部js或html资源
 
 - 0.4.1: 修改代码仓库名称

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gulp-h5packer
+# gulp-inline
 
 移动H5页面打包工具
 
@@ -7,6 +7,13 @@
 本插件可以根据link, script, img标签中的标记，选择将文件内容嵌入或者替换为CDN地址。
 
 ## 关键版本节点
+
+0.4.0: 基于`filow/gulp_h5packer`0.3.0版本进行优化与bug修复
+  - 解决关闭压缩后注入空脚本问题
+  - 解决压缩es2015规范代码异常
+  - 解决`htmlTag`配置变更后`staticUrl`替换失败问题
+  - 增加压缩是否采用严格模式配置
+  - 修改`htmlTag`默认值为`inline`
 
 0.3.0: 脱离支付宝H5开发环境独立发展
 
@@ -25,28 +32,27 @@
 ### 内容替换标记
 
 ```html
-<link rel="stylesheet" type="text/css" href="something.css" data-replace="true">
-<script src="something.js" data-replace="true"></script>
+<link rel="stylesheet" type="text/css" href="something.css" data-inline="true">
+<script src="something.js" data-inline="true"></script>
 ```
 
-这样会读取资源文件，把内容嵌入在标签的位置。script标签会删去src和data-replace属性，并在标签内嵌入内容。link标签会在后面产生一个style节点，并嵌入内容。标签本身会被删除。
-
-目前插件会自动压缩css和js文件，未来可以通过配置文件取消这一功能。
+这样会读取资源文件，把内容嵌入在标签的位置。script标签会删去src和data-inline属性，并在标签内嵌入内容。link标签会在后面产生一个style节点，并嵌入内容。标签本身会被删除。
 
 ### 资源URL替换标记
 
 ```html
-<link rel="stylesheet" type="text/css" href="local/amui.css" data-replace="amui">
-<script src="zepto.js" data-replace="static-zepto"></script>
+<link rel="stylesheet" type="text/css" href="local/animate.css" data-inline="static-animate">
+<script src="local/zepto.js" data-inline="static-zepto"></script>
 ```
 
-在data-replace中写入"static-全局资源包名称"，即可替换为相应的地址。
+在data-inline中写入"static-全局资源包名称"，即可替换为相应的地址。
 
 该功能由于目前脱离了支付宝环境，暂时没有默认值，请在初始化参数中传入：
 ```js
 {
   staticUrl: {
-    name: 'http://url.to.path'
+    animate: 'http://apps.bdimg.com/libs/animate.css/3.1.0/animate.min.css'
+    ,zepto: 'http://apps.bdimg.com/libs/zepto/1.1.4/zepto.min.js'
   }
 }
 
@@ -54,7 +60,7 @@
 
 ### 图片Base64转化标记
 ```html
-<img src="fake.png" data-replace="base64">
+<img src="fake.png" data-inline="base64">
 ```
 注意： 目前Base64转码不考虑文件大小因素，请不要在大图片上加这个标记！
 
@@ -62,14 +68,26 @@
 设置完HTML后，在gulpfile.js中引用：
 ```js
 gulp.task('pack', function (){
-  var replacer = require('gulp-h5replacer');
+  var inline = require('gulp-inline');
   gulp.src('./build/*/*.html')
-    .pipe(replacer())
-    .pipe(gulp.dest('./pack'));
+    .pipe(inline())
+    .pipe(gulp.dest('./public'));
 });
 ```
 
-## Todo
-1. 将文件引用的图片和无法嵌入的资源文件自动上传到蜻蜓上
-2. 增加配置选项
-3. 支持CSS内的图片BASE64
+## 参数
+
+| 属性 | 描述 | 是否必须 | 值类型 | 默认值 |
+|---- |:-------------:|:----:|:----:| ----:| 
+| `htmlTag` | 用于识别的属性 | 否 | {String} | "replace" |
+| `cssmin` | 是否开启css压缩 | 否 | {Boolean} | true |
+| `jsmin` | 是否开启js压缩 | 否 | {Boolean} | true |
+| `strict` | 是否使用严格模式 | 否 | {Boolean} | true |
+| `ignoreCompressFolders` | 不压缩的文件夹 | 否 | {Array-String} | [] |
+| `cssminConfig` | `clean-css`的配置 | 否 | {Object} | {} |
+| `jsminConfig` | `uglify-js`的配置| 否 | {Object} | {} |
+| `staticUrl` | `cdn`静态资源路径替换 | 否 | {Object} | {} |
+
+> 注：
+> - `clean-css`版本为`~3.3.7`
+> - `uglify-js`版本为`~2.4.24`

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 ### 脚本中内联
 
   ```js
-  __inline("./plugin/tinymce-plugin-autosave.js")
+  __inline('./plugin/tinymce-plugin-autosave.js')
   var uploadTpl = __inline('./tpls/upload.html');
   var EDITOR_CONFIG = __inline('./config/config.json');
   ```

--- a/lib/handler/embed.js
+++ b/lib/handler/embed.js
@@ -30,7 +30,7 @@ module.exports = function (elem, fileDir, config) {
     // 是否不压缩
     if(Object.prototype.toString.call(ignoreCompressFolders) === '[object Array]' && ignoreCompressFolders.length){
       for(var i = ignoreCompressFolders.length - 1; i >= 0; i--){
-        var item = "/" + ignoreCompressFolders[i] + "/";
+        var item = path.sep + ignoreCompressFolders[i] + path.sep;
         if(asset_path.indexOf(item) !== -1){
           ignore_min = true;
           break;
@@ -63,7 +63,10 @@ module.exports = function (elem, fileDir, config) {
         var UglifyJS = require("uglify-js");
         var presets = strict ? "es2015" : "es2015-without-strict";
         // 用babel转义，避免使用了es2015的语法导致压缩异常
-        var asset_content = babel.transform(asset_content, {presets: [presets]}).code;
+        var asset_content = babel.transform(asset_content, {
+          presets: [presets]
+          ,compact: false
+        }).code;
         asset_content = UglifyJS.minify(asset_content, _.merge(config.jsminConfig,{fromString: true})).code;
       }
       // script标签去除src和data-replace后，在内部添加内容

--- a/lib/handler/embed.js
+++ b/lib/handler/embed.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var _ = require('lodash');
 
 var unifyUrl = require('../unifyUrl');
+var babel = require("babel-core");
 
 // 处理文件内容的直接替换工具
 var tagUrl = {
@@ -21,29 +22,48 @@ module.exports = function (elem, fileDir, config) {
   unifyUrl(url, function (u) {
     // 资源的绝对路径
     var asset_path = path.resolve(fileDir, u);
+    // 是否忽略压缩的文件
+    var ignore_min = false;
+    // 不压缩文件的文件夹
+    var ignoreCompressFolders = config.ignoreCompressFolders;
+    // 是否不压缩
+    if(Object.prototype.toString.call(ignoreCompressFolders) === '[object Array]' && ignoreCompressFolders.length){
+      for(var i = ignoreCompressFolders.length - 1; i >= 0; i--){
+        var item = "/" + ignoreCompressFolders[i] + "/";
+        if(asset_path.indexOf(item) !== -1){
+          ignore_min = true;
+          break;
+        }
+      }
+    }
     // 资源的内容
     var asset_content = fs.readFileSync(asset_path, {encoding: 'utf8'});
     if(tagName == 'link'){
       // console.log(config);
-      if(config.cssmin){
+      var cssmin = config.cssmin && !ignore_min;
+      if(cssmin){
         var CleanCSS = require('clean-css');
         asset_content = new CleanCSS(config.cssminConfig).minify(asset_content).styles;
       }
-
       // link标签,就在后面生成一个style标签，去掉自身
       asset_content = '<style>' + asset_content + '</style>';
       elem.after(asset_content);
       elem.remove();
     }else if(tagName == 'script'){
-      if(config.jsmin) {
+      var jsmin = config.jsmin && !ignore_min;
+      // 是否使用严格模式
+      var strict = config.strict;
+      if(jsmin) {
         var UglifyJS = require("uglify-js");
-        asset_content = UglifyJS.minify(asset_content, _.merge(config.jsminConfig,{fromString: true}));
+        var presets = strict ? "es2015" : "es2015-without-strict";
+        // 用babel转义，避免使用了es2015的语法导致压缩异常
+        var asset_content = babel.transform(asset_content, {presets: [presets]}).code;
+        asset_content = UglifyJS.minify(asset_content, _.merge(config.jsminConfig,{fromString: true})).code;
       }
       // script标签去除src和data-replace后，在内部添加内容
       // .html()方法会有很多多余的操作
-      elem.text(asset_content.code);
+      elem.text(asset_content);
       elem.removeAttr('src');
     }
   });
-
 }

--- a/lib/handler/embed.js
+++ b/lib/handler/embed.js
@@ -10,6 +10,7 @@ var tagUrl = {
   link: 'href',
   script: 'src'
 };
+
 module.exports = function (elem, fileDir, config) {
   var tagName = elem[0].tagName.toLowerCase();
   // 只允许处理link和script标签
@@ -39,7 +40,7 @@ module.exports = function (elem, fileDir, config) {
     // 资源的内容
     var asset_content = fs.readFileSync(asset_path, {encoding: 'utf8'});
     if(tagName == 'link'){
-      // console.log(config);
+      // 是否压缩
       var cssmin = config.cssmin && !ignore_min;
       if(cssmin){
         var CleanCSS = require('clean-css');
@@ -50,6 +51,11 @@ module.exports = function (elem, fileDir, config) {
       elem.after(asset_content);
       elem.remove();
     }else if(tagName == 'script'){
+      // 脚本所在文件夹路径
+      var script_path = path.dirname(asset_path);
+      // 内联__inline标识资源
+      asset_content = inlineSrc(asset_content, script_path);
+      // 是否压缩
       var jsmin = config.jsmin && !ignore_min;
       // 是否使用严格模式
       var strict = config.strict;
@@ -66,4 +72,162 @@ module.exports = function (elem, fileDir, config) {
       elem.removeAttr('src');
     }
   });
+}
+
+/**
+ * 正则集
+ * @attr code  匹配__inline代码 eg: __inline('./config/config.json')
+ * @attr url   匹配__inline代码的路径 eg: "./config/config.json"
+ */
+var regexp = {
+  // 匹配__inline代码
+  code: new RegExp(/__inline\(.*?\)/, 'g')
+  // 匹配__inline代码的路径
+  ,url: new RegExp(/__inline\(['|"](.*)['|"]\)/)
+}
+
+/**
+ * 获取inline资源绝对路径
+ * @param {String} code "__inline"语句 eg: __inline('./config/config.json')
+ * @param {String} fileDir 当前路径
+ * @return {String} inline资源绝对路径
+ */
+function getUrl(code, fileDir){
+  var ret = "";
+  if(_.isString(code) && code.trim() !== '' && fileDir){
+    var result = code.match(regexp.url);
+    if(_.isArray(result) && result.length > 1){
+      var _result = result[1];
+      if(_.isString(_result) && _result.trim() !== ''){
+        ret = path.resolve(fileDir, _result);
+      }
+    }
+  }
+  return ret;
+}
+
+/**
+ * 获取文件类型
+ * @param {String} url 资源文件绝对路径
+ * @return {String} 文件类型
+ */
+function getFileType(url){
+  var ret = "";
+  if(_.isString(url) && url !== ''){
+    var result = url.replace(/.+\./, "");
+    if(result){
+      ret = result.trim();
+    }
+  }
+  return ret;
+}
+/**
+ * 装饰资源文件文本
+ * @param {String} content 资源文件文本
+ * @return {String} 装饰后资源文件文本
+ */
+function decorateContent(content, url){
+  var ret = content;
+  var type = getFileType(url);
+  switch(type){
+    case 'html':
+    case 'tpl':
+      ret = "`" + content + "`";
+      break;
+  }
+  return ret;
+}
+
+/**
+ * 获取inline资源内容
+ * @param {String} url 资源绝对路径
+ * @return {String} inline资源内容
+ */
+function getContent(url){
+  var ret = "";
+  if(_.isString(url) && url.trim() !== ''){
+    var options = {
+      encoding: 'utf8'
+    };
+    var inline_content = fs.readFileSync(url, options);
+    if(_.isString(inline_content)){
+      ret = decorateContent(inline_content, url);
+    }
+  }
+  return ret;
+}
+
+/**
+ * 获取inline语句与对应资源的对照
+ * @param {Array} inline_codes inline语句
+ * @param {String} fileDir 当前路径
+ * @return {Object} 
+ */
+function getInlineMap(inline_codes, fileDir){
+  var ret = {}
+  if(_.isArray(inline_codes) && inline_codes.length){
+    inline_codes.forEach(function(code){
+      if(code){
+        var url = getUrl(code, fileDir);
+        var cnt = getContent(url);
+        ret[code] = cnt;
+      }
+    })
+  }
+  return ret;
+}
+
+/**
+ * 根据inline语句生成正则表达式
+ * @param {String} inline_code inline语句
+ * @return {RegExp} 正则表达式 
+ */
+function getRegExp(inline_code){
+  var ret = null;
+  if(_.isString(inline_code) && inline_code !== ''){
+    var result = inline_code.replace(/\(/g, "\\(");
+    result = result.replace(/\)/g, "\\)");
+    ret = new RegExp(result, 'g');
+  }
+  return ret;
+}
+
+/**
+ * 将资源文本替换inline语句
+ * @param {Object} inline_map 资源对照
+ * @param {String} script 脚本源码
+ * @return {String} script 替换资源本文后的脚本源码
+ */
+function replaceInlineCode(inline_map, script){
+  if(_.isObject(inline_map) && Object.keys(inline_map).length && _.isString(script) && script !== ''){
+    Object.keys(inline_map).forEach(function(inline_code){
+      // 资源文本
+      var cnt = inline_map[inline_code];
+      // 正则表达式
+      var reg = getRegExp(inline_code);
+      if(reg){
+        script = script.replace(reg, cnt);
+      }
+    });
+  }
+  return script;
+}
+
+/**
+ * 内联"__inline"标识资源
+ * @param {String} script 脚本源码
+ * @param {String} fileDir 当前路径
+ * @return {String} script 替换资源本文后的脚本源码
+ */
+function inlineSrc(script, fileDir){
+  if(!script) return;
+  // 提取__inline语句 eg: ["__inline('./config/config.json')", "__inline('components/teditor/teditor.html')"]
+  var inline_codes = script.match(regexp.code);
+  // 资源索引
+  var inline_map = getInlineMap(inline_codes, fileDir);
+  // 替换inline语句为对应资源文本
+  if(inline_map) {
+    script = replaceInlineCode(inline_map, script);
+  }
+  return script;
 }

--- a/lib/handler/static-pack.js
+++ b/lib/handler/static-pack.js
@@ -8,17 +8,17 @@ var tagUrl = {
 };
 
 // 通过文件标示符将src替换为指定的地址
-module.exports = function (e, config){
-  var replaceAttr = e.data('replace').split('-');
+module.exports = function (e, config){ 
+  var replaceAttr = e.data(config.htmlTag).split('-');
   var tagName = e[0].tagName.toLowerCase();
   // 标签对应放置URL的地方
   var urlAttr = tagUrl[tagName];
 
   var repo = _.cloneDeep(CDNRepo);
   _.merge(repo, config.staticUrl);
-
+  console.log(repo[replaceAttr[1]]);
   if(repo[replaceAttr[1]]) {
     // 地址替换
-    e.attr(urlAttr, CDNRepo[replaceAttr[1]]);
+    e.attr(urlAttr, repo[replaceAttr[1]]);
   }
 }

--- a/lib/replacer.js
+++ b/lib/replacer.js
@@ -10,7 +10,7 @@ var base64 = require('./handler/base64.js');
 var _ = require('lodash');
 var defaultConfigs = {
   // 用于识别的属性
-  htmlTag: 'replace',
+  htmlTag: 'inline',
   // 是否开启css压缩
   cssmin: true,
   // 是否开启js压缩

--- a/lib/replacer.js
+++ b/lib/replacer.js
@@ -15,9 +15,13 @@ var defaultConfigs = {
   cssmin: true,
   // 是否开启js压缩
   jsmin: true,
+  // 是否严格模式
+  strict: true,
+  // 不压缩文件的文件夹
+  ignoreCompressFolders: [],
   cssminConfig: {},
   jsminConfig: {},
-  staticUrl: {},
+  staticUrl: {}
 };
 
 function rawReplace(filePath, fileContents, cfg, cb){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "gulp-h5packer",
-  "version": "0.3.1",
+  "name": "gulp-inline",
+  "version": "0.4.0",
   "description": "移动H5页面打包工具，可以根据描述将资源打包进html，替换资源为全局资源包CDN地址，减少请求数量",
   "main": "index.js",
   "scripts": {
@@ -11,16 +11,17 @@
     "html5",
     "packer",
     "gulp",
-    "gulp-h5packer"
+    "gulp-h5packer",
+    "gulp-inline"
   ],
-  "author": "李仁海",
+  "author": "黄俊文",
   "license": "ISC",
   "repository": {
     "type": "git",
-    "url": "https://github.com/filow/gulp_h5packer.git"
+    "url": "https://github.com/blackstone86/gulp_h5packer.git"
   },
   "bugs": {
-    "url": "https://github.com/filow/gulp_h5packer/issues"
+    "url": "https://github.com/blackstone86/gulp_h5packer/issues"
   },
   "dependencies": {
     "babel-core": "^6.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "gulp-inline",
-  "version": "0.4.0",
+  "name": "gulp-inline-src",
+  "version": "0.4.1",
   "description": "移动H5页面打包工具，可以根据描述将资源打包进html，替换资源为全局资源包CDN地址，减少请求数量",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-inline-src",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "资源内联插件，对html或js中引用的外部资源通过内联方式嵌入",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
   "license": "ISC",
   "repository": {
     "type": "git",
-    "url": "https://github.com/blackstone86/gulp_inline.git"
+    "url": "https://github.com/blackstone86/gulp_inline_src.git"
   },
   "bugs": {
-    "url": "https://github.com/blackstone86/gulp_inline/issues"
+    "url": "https://github.com/blackstone86/gulp_inline_src/issues"
   },
   "dependencies": {
     "babel-core": "^6.25.0",

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
   "license": "ISC",
   "repository": {
     "type": "git",
-    "url": "https://github.com/blackstone86/gulp_h5packer.git"
+    "url": "https://github.com/blackstone86/gulp_inline.git"
   },
   "bugs": {
-    "url": "https://github.com/blackstone86/gulp_h5packer/issues"
+    "url": "https://github.com/blackstone86/gulp_inline/issues"
   },
   "dependencies": {
     "babel-core": "^6.25.0",

--- a/package.json
+++ b/package.json
@@ -1,20 +1,26 @@
 {
   "name": "gulp-inline-src",
-  "version": "0.4.1",
-  "description": "移动H5页面打包工具，可以根据描述将资源打包进html，替换资源为全局资源包CDN地址，减少请求数量",
+  "version": "0.4.2",
+  "description": "资源内联插件，对html或js中引用的外部资源通过内联方式嵌入",
   "main": "index.js",
   "scripts": {
     "test": "mocha"
   },
   "keywords": [
+    "gulp",
     "gulpplugin",
+    "gulp-plugin",
+    "h5",
     "html5",
     "packer",
-    "gulp",
+    "builder",
     "gulp-h5packer",
-    "gulp-inline"
+    "gulp-html5packer",
+    "gulp-inline",
+    "gulp-inline-src"
   ],
-  "author": "黄俊文",
+  "author": "blackstone86",
+  "email": "asianking86@qq.com",
   "license": "ISC",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-inline-src",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "资源内联插件，对html或js中引用的外部资源通过内联方式嵌入",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,12 +23,16 @@
     "url": "https://github.com/filow/gulp_h5packer/issues"
   },
   "dependencies": {
+    "babel-core": "^6.25.0",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-es2015-without-strict": "0.0.4",
     "base64-img": "~1.0.3",
     "cheerio": "~0.19.0",
     "clean-css": "~3.3.7",
     "gulp-util": "~3.0.6",
     "lodash": "~3.10.1",
     "request": "^2.67.0",
+    "sync-request": "^4.1.0",
     "through2": "~2.0.0",
     "uglify-js": "~2.4.24"
   },


### PR DESCRIPTION
0.4.1: 基于`filow/gulp_h5packer`0.3.0版本进行优化与bug修复
  - 解决关闭压缩后注入空脚本问题
  - 解决压缩es2015规范代码异常
  - 解决`htmlTag`配置变更后`staticUrl`替换失败问题
  - 增加压缩是否采用严格模式配置
  - 修改`htmlTag`默认值为`inline`，感觉语义好一点